### PR TITLE
Update dcm2niix dependency to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib>=3.8.0",
     "pydantic>=2.5.0",
     "pyyaml>=6.0",
-    "dcm2niix>=1.0.20250506",
+    "dcm2niix>=1.0.20260416",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -447,24 +447,17 @@ wheels = [
 
 [[package]]
 name = "dcm2niix"
-version = "1.0.20250506"
+version = "1.0.20260416"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/3c/26646fa41e690c3141cf4e936fa7a6fd1caf511ab8795e93a6f658e0ef95/dcm2niix-1.0.20250506.tar.gz", hash = "sha256:f0bbdf030b6b84d2cdbd073904126ac10abd0afde2a52e266908437abf35c27c", size = 545248, upload-time = "2025-05-28T12:16:19.034Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/5f62409d488b771e8b7b17bee8023d35c3f745af685df1a863c402f3adf7/dcm2niix-1.0.20260416.tar.gz", hash = "sha256:65ed563d218e38ea5a836a756bd1bd5298377489a70f44c06dc11b807969f4b6", size = 566798, upload-time = "2026-05-07T20:14:09.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/5e/85565e2f116505fb1380778eee5f1c4d2e714fbac7f82f50902f7e23a9e8/dcm2niix-1.0.20250506-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ec5b6ac3ab94fb4b6e7a67aa83778a557928cafe8a13d3e9c9e803e2abf4e270", size = 558903, upload-time = "2025-05-28T12:15:27.519Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/65/c8c79cd512ba9b37e1d774907631145e106446adb6e8f2631c6688d1caf2/dcm2niix-1.0.20250506-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5fe472ea9bfaa117b7cc97826cfc853e245f1a900ac2abea4961f6631b103aa7", size = 505321, upload-time = "2025-05-28T12:15:28.797Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/84/d887bdf53fe99787548f86d969e70088c3fb913071336be251c945ac1d02/dcm2niix-1.0.20250506-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91700a215f21e76d323fc31fb8eb43669ddfb75ab32c74a065fbc0c66ddfc37a", size = 578817, upload-time = "2025-05-28T12:15:29.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/ce/9406d41ad9f6488c84207a82e01dc420e2c4d1577ec007a92d5af57414d6/dcm2niix-1.0.20250506-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3c9ca037696d379fcb6c65bd4f350b0e9f92a1ef66ec1bd30f7d6017f2a31c8", size = 573420, upload-time = "2025-05-28T12:15:31.254Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5f/c518c99b7ed4e439f73ee03da73c90fd865dc0a1731ac1f8ce4c31466c49/dcm2niix-1.0.20250506-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d0c5ac38ee675985b3e27e44644e87d39eb37fb2ff5589f93b2960f5e32f2800", size = 630216, upload-time = "2025-05-28T12:15:32.588Z" },
-    { url = "https://files.pythonhosted.org/packages/25/6f/cbbeca77a9bac59cc6f6c243a56a18a370c6fa03e380662d29faf1e587c2/dcm2niix-1.0.20250506-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4eafae2a7c74a84cb465d7288a20d4d08256163221f85cc09ad6dbbbd3933155", size = 627525, upload-time = "2025-05-28T12:15:33.983Z" },
-    { url = "https://files.pythonhosted.org/packages/97/22/e0e29368897aae0e2e8dddc528813963f0cfa308dc0c994f88bf87552911/dcm2niix-1.0.20250506-cp312-cp312-win_amd64.whl", hash = "sha256:c65b876a5eafe45fe8be42a5770e80f893f232fe85c5aa3ac9692453722b43a0", size = 714271, upload-time = "2025-05-28T12:15:35.19Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e7/a69cb8696fc21515ce6630ecb1eb115bc5978719226c444547488936e298/dcm2niix-1.0.20250506-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1550f9e30aff4e2d274f2ce814a28ff6ef65992022400f1f47d4e92afbb29af9", size = 558903, upload-time = "2025-05-28T12:15:37.195Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c4/849fc7f01794c513d1ecd84d0bbe3e9a201695efe17f909982236a7c36b3/dcm2niix-1.0.20250506-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4429c01176625dbba9c47f8e2072731183d20832cb17a7dd0d52f15a90301e99", size = 505320, upload-time = "2025-05-28T12:15:39.181Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9b/6bc7cd89c9724c11739e89625e001528eae4cb1ff1ab4e3a4f55480e4f54/dcm2niix-1.0.20250506-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1395cef3d27af2a3e806e2135d80f6cf1f1132f5d7acc0ac3ffcc22ee33a443", size = 578817, upload-time = "2025-05-28T12:15:40.87Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a4/ee67e1a7c496ba46aee597dad400972a33dee9ab38f066a6e5769f29904e/dcm2niix-1.0.20250506-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:534108ca2aa2f7f9be578caf22ba77cbc64e99ccdf82a7102ed15d610e8d8529", size = 573419, upload-time = "2025-05-28T12:15:43.249Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7d/3050c1b53466fefdcc9c0ab3b8cadd2f2c8f727d6044458870304cf1c9dc/dcm2niix-1.0.20250506-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fda042fa706fbcbc8f3950333a503a4fd1546abea4c32aec018770f0d3789725", size = 630217, upload-time = "2025-05-28T12:15:44.721Z" },
-    { url = "https://files.pythonhosted.org/packages/92/97/277e1be4cc06bfc6bee9a97b077a9ecf8ba058348afe71b51e51af82ada6/dcm2niix-1.0.20250506-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:979e238f4dd0d5339dec40d400b9d507397fa61ef78a35ce80017aeb8fbea0f5", size = 627523, upload-time = "2025-05-28T12:15:46.163Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/b0/22572b7931a86e7d333ee25578d80d743c8e5d6f442e431d603eb80fa8b4/dcm2niix-1.0.20250506-cp313-cp313-win_amd64.whl", hash = "sha256:a8e5e245012d0c3d3564d58e388dc953c11494a2f485a28410c35ab6989e8e53", size = 714270, upload-time = "2025-05-28T12:15:47.517Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f7/031d62ab7cfa104b6139f615c3e048d1e2d50ec4fe7441939dafd7f927d1/dcm2niix-1.0.20260416-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6789bada369fc3c6c8f71521a2d8a615a27534f591757db4a9e616caecdb7ba4", size = 1086688, upload-time = "2026-05-07T20:13:57.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8b/e7e64c05645d1a67d6e034a9a4fcff642f4cb6fdec16c1600618cde6bd42/dcm2niix-1.0.20260416-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:e16bd062eccffc7740e93250561b894c5664325bebfb8b59fbf90227b8ccdfc5", size = 1019193, upload-time = "2026-05-07T20:13:59.273Z" },
+    { url = "https://files.pythonhosted.org/packages/99/00/42dcf199dd76f1d59acf8e53d71c1a36c672c29f72d7385f1d51d20e1cd3/dcm2niix-1.0.20260416-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69e42958deffc7d71b323c17aab31555c43f6f1acac045cca810a4f5f5fb9261", size = 1998175, upload-time = "2026-05-07T20:14:01.058Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/4adf9bd64a123cf0c1ffb882362bf79a0022a315d29abd8929bedaafdf70/dcm2niix-1.0.20260416-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9c5e42819c18f58942c2ed138199e81f294f9c96874e29b675b737e1b69a596", size = 1949123, upload-time = "2026-05-07T20:14:03.105Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1a/64da2cfe3072cfacaa9dc5985d793de4279894ffe98d5805425b42f63b6e/dcm2niix-1.0.20260416-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2eb75032ced26c3a66fb09b46dfa725b774b718914f4f29b10241702ae85da6c", size = 2285615, upload-time = "2026-05-07T20:14:04.573Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/b5e85eb70ac8d9289cfaf30c5a99079d9a89236254ab1827ddb6133c3b11/dcm2niix-1.0.20260416-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cc1ef067b1b290118150eab7f4c44947321f058998dbcf018e714e2e9e389236", size = 2272582, upload-time = "2026-05-07T20:14:06.313Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7f/c87fad5be26a52cc0351a8aca4a4b7aa8f4ab7835467ae6715a7536504a8/dcm2niix-1.0.20260416-cp38-abi3-win_amd64.whl", hash = "sha256:7c03bd92cd72640061a25e86c16bda28e76a822b0d14ece8bd40a53244f30e1b", size = 2393233, upload-time = "2026-05-07T20:14:07.977Z" },
 ]
 
 [[package]]
@@ -1506,7 +1499,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0.0" },
-    { name = "dcm2niix", specifier = ">=1.0.20250506" },
+    { name = "dcm2niix", specifier = ">=1.0.20260416" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0" },


### PR DESCRIPTION
Bump **`dcm2niix`** to `1.0.20260416 `to fix `uv sync` on Windows (older version has no Windows wheel).
Closes #149.