### PR TITLE
Fix fabricated and garbled literature citations

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -661,27 +661,27 @@ Functions raise exceptions for structural errors. Individual voxel fitting failu
 ### Key Literature References
 
 **DCE-MRI**:
-- Tofts PS, Kermode AG (1991). Measurement of the blood-brain barrier permeability. *Magn Reson Med*.
-- Tofts PS et al. (1999). Estimating kinetic parameters from DCE-MRI. *JMRI*.
-- Parker GJM et al. (2006). Population-averaged AIF. *Magn Reson Med*.
-- Weinmann HJ et al. (1984). Pharmacokinetics of GdDTPA. *Physiol Chem Phys Med NMR*.
+- Tofts PS, Kermode AG (1991). Measurement of the blood-brain barrier permeability and leakage space using dynamic MR imaging. 1. Fundamental concepts. *Magn Reson Med*. 17(2):357-367.
+- Tofts PS et al. (1999). Estimating kinetic parameters from dynamic contrast-enhanced T1-weighted MRI of a diffusable tracer: standardized quantities and symbols. *J Magn Reson Imaging*. 10(3):223-232.
+- Parker GJM et al. (2006). Experimentally-derived functional form for a population-averaged high-temporal-resolution arterial input function for dynamic contrast-enhanced MRI. *Magn Reson Med*. 56(5):993-1000.
+- Weinmann HJ, Laniado M, Mützel W (1984). Pharmacokinetics of GdDTPA/dimeglumine after intravenous injection into healthy volunteers. *Physiol Chem Phys Med NMR*. 16:167-172.
 
 **DSC-MRI**:
-- Ostergaard L et al. (1996). High resolution CBF measurement. *Magn Reson Med*.
-- Boxerman JL et al. (2006). Leakage-corrected rCBV maps. *AJNR*.
-- Wu O et al. (2003). Timing-insensitive flow estimation (cSVD/oSVD). *Magn Reson Med*.
+- Ostergaard L et al. (1996). High resolution measurement of cerebral blood flow using intravascular tracer bolus passages. Part I: Mathematical approach and statistical analysis. *Magn Reson Med*. 36(5):715-725.
+- Boxerman JL, Schmainda KM, Weisskoff RM (2006). Relative cerebral blood volume maps corrected for contrast agent extravasation significantly correlate with glioma tumor grade, whereas uncorrected maps do not. *AJNR Am J Neuroradiol*. 27(4):859-867.
+- Wu O et al. (2003). Tracer arrival timing-insensitive technique for estimating flow in MR perfusion-weighted imaging using singular value decomposition with a block-circulant deconvolution matrix. *Magn Reson Med*. 50(1):164-174.
 
 **ASL**:
-- Buxton RB et al. (1998). General kinetic model for ASL. *Magn Reson Med*.
-- Alsop DC et al. (2015). Recommended ASL implementation. *Magn Reson Med*.
+- Buxton RB et al. (1998). A general kinetic model for quantitative perfusion imaging with arterial spin labeling. *Magn Reson Med*. 40(3):383-396.
+- Alsop DC et al. (2015). Recommended implementation of arterial spin-labeled perfusion MRI for clinical applications: a consensus of the ISMRM Perfusion Study Group and the European Consortium for ASL in Dementia. *Magn Reson Med*. 73(1):102-116.
 
 **IVIM**:
-- Le Bihan D et al. (1988). IVIM MR imaging. *Radiology*.
-- Federau C (2017). IVIM as perfusion measure. *NMR Biomed*.
+- Le Bihan D et al. (1988). Separation of diffusion and perfusion in intravoxel incoherent motion MR imaging. *Radiology*. 168(2):497-505.
+- Federau C (2017). Intravoxel incoherent motion MRI as a means to measure in vivo perfusion: a review of the evidence. *NMR Biomed*. 30(11):e3780.
 
 **Convolution**:
-- Flouri D, Lesnic D, Mayrovitz HN (2016). Numerical solution of convolution integral equations in pharmacokinetics. *Comput Methods Biomech Biomed Eng*.
-- Sourbron & Buckley (2013). Tracer kinetic modelling in MRI. *NMR Biomed*.
+- Flouri D, Lesnic D, Sourbron SP (2016). Fitting the two-compartment model in DCE-MRI by linear inversion. *Magn Reson Med*. 76(3):998-1006.
+- Sourbron & Buckley (2013). Classic models for dynamic contrast-enhanced MRI. *NMR Biomed*. 26(8):1004-1027.
 
 ### Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -187,5 +187,5 @@ MIT License
 ## References
 
 - [OSIPI (Open Science Initiative for Perfusion Imaging)](https://www.osipi.org/)
-- Dickie BR et al. CAPLEX: a standardized reporting framework for perfusion MRI. *MRM* 2024;91(5):1761-1773. [doi:10.1002/mrm.29840](https://doi.org/10.1002/mrm.29840)
+- Dickie BR et al. A community-endorsed open-source lexicon for contrast agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). *MRM* 2024;91(5):1761-1773. [doi:10.1002/mrm.29840](https://doi.org/10.1002/mrm.29840)
 - Suzuki Y et al. OSIPI ASL Lexicon. *MRM* 2024;91(5):1743-1760. [doi:10.1002/mrm.29815](https://doi.org/10.1002/mrm.29815)

--- a/docs/how-to/add-bbb-asl-model.md
+++ b/docs/how-to/add-bbb-asl-model.md
@@ -101,7 +101,7 @@ Extend `ASLQuantificationParams` with multi-echo and exchange parameters.
         References
         ----------
         .. [1] OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
-        .. [2] St. Lawrence KS et al. JCBFM 2012;32:874-887.
+        .. [2] St. Lawrence KS, Owen D, Wang DJJ. MRM 2012;67(5):1275-1284. doi:10.1002/mrm.23104
         """
 
         echo_times: list[float] = field(default_factory=lambda: [10.0, 30.0, 50.0])
@@ -138,8 +138,8 @@ optional `quantify()` method.
         References
         ----------
         .. [1] OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
-        .. [2] St. Lawrence KS et al. JCBFM 2012;32:874-887.
-        .. [3] Wengler K et al. NeuroImage 2020;220:117101.
+        .. [2] St. Lawrence KS, Owen D, Wang DJJ. MRM 2012;67(5):1275-1284. doi:10.1002/mrm.23104
+        .. [3] Wengler K et al. NeuroImage 2019;189:401-414.
         """
 
         @property
@@ -156,7 +156,7 @@ optional `quantify()` method.
 
         @property
         def reference(self) -> str:
-            return "St. Lawrence KS et al. JCBFM 2012;32:874-887."
+            return "St. Lawrence KS, Owen D, Wang DJJ. MRM 2012;67(5):1275-1284. doi:10.1002/mrm.23104"
 
         @property
         def labeling_type(self) -> str:
@@ -262,7 +262,7 @@ This model inherits from `BaseASLModel` and provides a forward prediction via it
         ----------
         .. [1] OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
         .. [2] Buxton RB et al. MRM 1998;40(3):383-396.
-        .. [3] St. Lawrence KS et al. JCBFM 2012;32:874-887.
+        .. [3] St. Lawrence KS, Owen D, Wang DJJ. MRM 2012;67(5):1275-1284. doi:10.1002/mrm.23104
         """
 
         @property
@@ -279,7 +279,7 @@ This model inherits from `BaseASLModel` and provides a forward prediction via it
 
         @property
         def reference(self) -> str:
-            return "St. Lawrence KS et al. JCBFM 2012;32:874-887."
+            return "St. Lawrence KS, Owen D, Wang DJJ. MRM 2012;67(5):1275-1284. doi:10.1002/mrm.23104"
 
         @property
         def labeling_type(self) -> str:
@@ -517,7 +517,7 @@ By using the `BaseASLModel` hierarchy, your BBB ASL model automatically gets:
 ## References
 
 1. St. Lawrence KS, Owen D, Wang DJJ. A two-stage approach for measuring vascular water exchange and arterial transit time by diffusion-weighted perfusion MRI. *Magn Reson Med*. 2012;67(5):1275-1284.
-2. Wengler K, Bangiyev L, Engel T, et al. 3D MRI of whole-brain water permeability with intrinsic diffusivity encoding of arterial labeled spin (IDEALS). *NeuroImage*. 2020;220:117101.
+2. Wengler K, Bangiyev L, Canli T, et al. 3D MRI of whole-brain water permeability with intrinsic diffusivity encoding of arterial labeled spin (IDEALS). *NeuroImage*. 2019;189:401-414.
 3. Shao X, Ma SJ, Casey M, et al. Mapping water exchange across the blood-brain barrier using 3D diffusion-prepared arterial spin labeled perfusion MRI. *Magn Reson Med*. 2019;81(5):3065-3079.
 4. OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
 5. Suzuki Y et al. *MRM* 2024;91(5):1743-1760. doi:10.1002/mrm.29815

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -661,27 +661,27 @@ Functions raise exceptions for structural errors. Individual voxel fitting failu
 ### Key Literature References
 
 **DCE-MRI**:
-- Tofts PS, Kermode AG (1991). Measurement of the blood-brain barrier permeability. *Magn Reson Med*.
-- Tofts PS et al. (1999). Estimating kinetic parameters from DCE-MRI. *JMRI*.
-- Parker GJM et al. (2006). Population-averaged AIF. *Magn Reson Med*.
-- Weinmann HJ et al. (1984). Pharmacokinetics of GdDTPA. *Physiol Chem Phys Med NMR*.
+- Tofts PS, Kermode AG (1991). Measurement of the blood-brain barrier permeability and leakage space using dynamic MR imaging. 1. Fundamental concepts. *Magn Reson Med*. 17(2):357-367.
+- Tofts PS et al. (1999). Estimating kinetic parameters from dynamic contrast-enhanced T1-weighted MRI of a diffusable tracer: standardized quantities and symbols. *J Magn Reson Imaging*. 10(3):223-232.
+- Parker GJM et al. (2006). Experimentally-derived functional form for a population-averaged high-temporal-resolution arterial input function for dynamic contrast-enhanced MRI. *Magn Reson Med*. 56(5):993-1000.
+- Weinmann HJ, Laniado M, Mützel W (1984). Pharmacokinetics of GdDTPA/dimeglumine after intravenous injection into healthy volunteers. *Physiol Chem Phys Med NMR*. 16:167-172.
 
 **DSC-MRI**:
-- Ostergaard L et al. (1996). High resolution CBF measurement. *Magn Reson Med*.
-- Boxerman JL et al. (2006). Leakage-corrected rCBV maps. *AJNR*.
-- Wu O et al. (2003). Timing-insensitive flow estimation (cSVD/oSVD). *Magn Reson Med*.
+- Ostergaard L et al. (1996). High resolution measurement of cerebral blood flow using intravascular tracer bolus passages. Part I: Mathematical approach and statistical analysis. *Magn Reson Med*. 36(5):715-725.
+- Boxerman JL, Schmainda KM, Weisskoff RM (2006). Relative cerebral blood volume maps corrected for contrast agent extravasation significantly correlate with glioma tumor grade, whereas uncorrected maps do not. *AJNR Am J Neuroradiol*. 27(4):859-867.
+- Wu O et al. (2003). Tracer arrival timing-insensitive technique for estimating flow in MR perfusion-weighted imaging using singular value decomposition with a block-circulant deconvolution matrix. *Magn Reson Med*. 50(1):164-174.
 
 **ASL**:
-- Buxton RB et al. (1998). General kinetic model for ASL. *Magn Reson Med*.
-- Alsop DC et al. (2015). Recommended ASL implementation. *Magn Reson Med*.
+- Buxton RB et al. (1998). A general kinetic model for quantitative perfusion imaging with arterial spin labeling. *Magn Reson Med*. 40(3):383-396.
+- Alsop DC et al. (2015). Recommended implementation of arterial spin-labeled perfusion MRI for clinical applications: a consensus of the ISMRM Perfusion Study Group and the European Consortium for ASL in Dementia. *Magn Reson Med*. 73(1):102-116.
 
 **IVIM**:
-- Le Bihan D et al. (1988). IVIM MR imaging. *Radiology*.
-- Federau C (2017). IVIM as perfusion measure. *NMR Biomed*.
+- Le Bihan D et al. (1988). Separation of diffusion and perfusion in intravoxel incoherent motion MR imaging. *Radiology*. 168(2):497-505.
+- Federau C (2017). Intravoxel incoherent motion MRI as a means to measure in vivo perfusion: a review of the evidence. *NMR Biomed*. 30(11):e3780.
 
 **Convolution**:
-- Flouri D, Lesnic D, Mayrovitz HN (2016). Numerical solution of convolution integral equations in pharmacokinetics. *Comput Methods Biomech Biomed Eng*.
-- Sourbron & Buckley (2013). Tracer kinetic modelling in MRI. *NMR Biomed*.
+- Flouri D, Lesnic D, Sourbron SP (2016). Fitting the two-compartment model in DCE-MRI by linear inversion. *Magn Reson Med*. 76(3):998-1006.
+- Sourbron & Buckley (2013). Classic models for dynamic contrast-enhanced MRI. *NMR Biomed*. 26(8):1004-1027.
 
 ### Key Conventions
 

--- a/docs/tutorials/dce-analysis.md
+++ b/docs/tutorials/dce-analysis.md
@@ -128,7 +128,7 @@ acq_params = DCEAcquisitionParams(
     flip_angles=[15],  # degrees (DCE flip angle)
     baseline_frames=5,
     relaxivity=4.5,    # mM^-1 s^-1 — Gd-DTPA in water at 3T
-                       # (Noebauer-Huhmann 2005, PMID 16462135: R1_3T_water=4.50).
+                       # (Sasaki 2005, PMID 16462135: R1_3T_water=4.50).
                        # In vivo plasma r1 at 3T is lower; override for
                        # agent-specific in-vivo accuracy.
 )

--- a/osipy/asl/__init__.py
+++ b/osipy/asl/__init__.py
@@ -24,7 +24,9 @@ References
    spin-labeled perfusion MRI for clinical applications: A consensus of
    the ISMRM Perfusion Study Group and the European Consortium for ASL
    in Dementia. Magn Reson Med 73(1):102-116.
-.. [3] Suzuki Y et al. (2024). MRM 91(4):1411-1421.
+.. [3] Suzuki Y et al. (2024). ASL lexicon and reporting
+   recommendations: A consensus report from the ISMRM Open Science
+   Initiative for Perfusion Imaging (OSIPI). MRM 91(5):1743-1760.
 """
 
 # Labeling schemes

--- a/osipy/asl/calibration/m0.py
+++ b/osipy/asl/calibration/m0.py
@@ -13,8 +13,8 @@ References
 .. [2] Alsop DC et al. (2015). Recommended implementation of arterial
    spin-labeled perfusion MRI for clinical applications.
    Magn Reson Med 73(1):102-116.
-.. [3] Chappell MA et al. (2009). Separation of macrovascular signal in
-   multi-inversion time arterial spin labeling MRI.
+.. [3] Chappell MA et al. (2010). Separation of macrovascular signal in
+   multi-inversion time arterial spin labelling MRI.
    Magn Reson Med 63(5):1357-1365.
 """
 

--- a/osipy/asl/quantification/multi_pld.py
+++ b/osipy/asl/quantification/multi_pld.py
@@ -17,7 +17,9 @@ References
 .. [3] Dai W et al. (2012). Reduced resolution transit delay prescan for
    quantitative continuous arterial spin labeling perfusion imaging.
    Magn Reson Med 67(5):1252-1265.
-.. [4] Suzuki Y et al. (2024). MRM 91(4):1411-1421.
+.. [4] Suzuki Y et al. (2024). ASL lexicon and reporting recommendations: A
+   consensus report from the ISMRM Open Science Initiative for Perfusion
+   Imaging (OSIPI). MRM 91(5):1743-1760.
 """
 
 from __future__ import annotations

--- a/osipy/common/__init__.py
+++ b/osipy/common/__init__.py
@@ -24,7 +24,10 @@ validation
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from
+   the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+   MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from osipy.common.convolution import (

--- a/osipy/common/aif/base.py
+++ b/osipy/common/aif/base.py
@@ -12,7 +12,10 @@ References
 .. [1] Parker GJM et al. (2006). Experimentally-derived functional form
    for a population-averaged AIF. Magn Reson Med 56(5):993-1000.
 .. [2] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [3] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [3] Dickie BR et al. A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from
+   the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+   MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from abc import abstractmethod

--- a/osipy/common/aif/detection.py
+++ b/osipy/common/aif/detection.py
@@ -558,7 +558,7 @@ class MultiCriteriaAIFDetector(BaseAIFDetector):
     @property
     def reference(self) -> str:
         """Literature reference for the detection algorithm."""
-        return "Peruzzo D et al. MRM 2011;66(2):461-472."
+        return "Peruzzo D et al. Comput Methods Programs Biomed 2011;104(3):e148-e157."
 
     def detect(self, dataset, params=None, roi_mask=None):
         """Detect AIF using multi-criteria approach.

--- a/osipy/common/aif/population.py
+++ b/osipy/common/aif/population.py
@@ -15,16 +15,20 @@ References
 .. [1] Parker GJM et al. (2006). Experimentally-derived functional form for a
    population-averaged high-temporal-resolution arterial input function for
    dynamic contrast-enhanced MRI. Magn Reson Med 56(5):993-1000.
-.. [2] Georgiou L et al. (2014). A functional form for a representative
-   individual arterial input function. Magn Reson Med 73(3):1241-1249.
-.. [3] Fritz-Hansen T et al. (1996). Capillary transfer constant of Gd-DTPA
+.. [2] Georgiou L et al. (2019). A functional form for a representative
+   individual arterial input function measured from a population using high
+   temporal resolution DCE MRI. Magn Reson Med 81(3):1955-1963.
+.. [3] Fritz-Hansen T et al. (1998). Capillary transfer constant of Gd-DTPA
    in the myocardium at rest and during vasodilation assessed by MRI.
-   Magn Reson Med 35(2):139-144.
+   Magn Reson Med 40(6):922-929. doi:10.1002/mrm.1910400619
 .. [4] Weinmann HJ et al. (1984). Pharmacokinetics of GdDTPA/dimeglumine after
    intravenous injection into healthy volunteers. Physiological Chemistry
    and Physics and Medical NMR 16(2):167-172.
 .. [5] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [6] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [6] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+   agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open
+   Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):1761-1773.
+   doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass
@@ -223,7 +227,7 @@ class GeorgiouAIFParams:
     The Georgiou AIF extends the Parker model with improved individual
     variability handling.
 
-    Default values are from Georgiou et al. (2014).
+    Default values are from Georgiou et al. (2019).
     """
 
     # First Gaussian
@@ -252,7 +256,7 @@ class GeorgiouAIF(BaseAIF):
 
     References
     ----------
-    .. [1] Georgiou L et al. (2014). Magn Reson Med 73(3):1241-1249.
+    .. [1] Georgiou L et al. (2019). Magn Reson Med 81(3):1955-1963.
     .. [2] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
     """
 
@@ -274,7 +278,7 @@ class GeorgiouAIF(BaseAIF):
     @property
     def reference(self) -> str:
         """Return literature citation."""
-        return "Georgiou L et al. (2014). Magn Reson Med 73(3):1241-1249."
+        return "Georgiou L et al. (2019). Magn Reson Med 81(3):1955-1963."
 
     def get_parameters(self) -> dict[str, float]:
         """Return current AIF model parameters."""
@@ -386,7 +390,10 @@ class FritzHansenAIF(BaseAIF):
 
     References
     ----------
-    Fritz-Hansen T et al. (1996). Magn Reson Med 35(2):139-144.
+    Fritz-Hansen T, Rostrup E, Larsson HB, Søndergaard L, Ring P, Henriksen O
+    (1996). Measurement of the arterial concentration of Gd-DTPA using MRI: a
+    step toward quantitative perfusion imaging. Magn Reson Med 36(2):225-231.
+    doi:10.1002/mrm.1910360209
     """
 
     def __init__(self, params: FritzHansenAIFParams | None = None) -> None:
@@ -407,7 +414,7 @@ class FritzHansenAIF(BaseAIF):
     @property
     def reference(self) -> str:
         """Return literature citation."""
-        return "Fritz-Hansen T et al. (1996). Magn Reson Med 35(2):139-144."
+        return "Fritz-Hansen T et al. (1996). Magn Reson Med 36(2):225-231."
 
     def get_parameters(self) -> dict[str, float]:
         """Return current AIF model parameters."""

--- a/osipy/common/convolution/__init__.py
+++ b/osipy/common/convolution/__init__.py
@@ -17,11 +17,12 @@ Key functions:
 
 References
 ----------
-.. [1] Flouri D, Lesnic D, Mayrovitz HN (2016). Numerical solution of the
-   convolution integral equations in pharmacokinetics. Comput Methods
-   Biomech Biomed Engin. 19(13):1359-1367.
-.. [2] Sourbron & Buckley (2013). Tracer kinetic modelling in MRI.
-   NMR Biomed. 26(8):1034-1048.
+.. [1] Flouri D, Lesnic D, Sourbron SP (2016). Fitting the two-compartment
+   model in DCE-MRI by linear inversion. Magn Reson Med. 76(3):998-1006.
+   doi:10.1002/mrm.25991
+.. [2] Sourbron & Buckley (2013). Classic models for dynamic
+   contrast-enhanced MRI. NMR Biomed. 26(8):1004-1027.
+   doi:10.1002/nbm.2940
 .. [3] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
 """
 

--- a/osipy/common/convolution/conv.py
+++ b/osipy/common/convolution/conv.py
@@ -8,8 +8,8 @@ when time sampling is non-uniform.
 References
 ----------
     - dcmri (https://github.com/dcmri/dcmri) utils.conv()
-    - Sourbron & Buckley (2013). Tracer kinetic modelling in MRI.
-      NMR Biomed. 26(8):1034-1048.
+    - Sourbron & Buckley (2013). Classic models for dynamic
+      contrast-enhanced MRI. NMR Biomed. 26(8):1004-1027.
 """
 
 from __future__ import annotations

--- a/osipy/common/convolution/expconv.py
+++ b/osipy/common/convolution/expconv.py
@@ -9,9 +9,9 @@ NO scipy dependency - see XP Compatibility Requirements in plan.md.
 
 References
 ----------
-Flouri D, Lesnic D, Mayrovitz HN (2016). Numerical solution of the
-convolution integral equations in pharmacokinetics. Comput Methods
-Biomech Biomed Engin. 19(13):1359-1367.
+Flouri D, Lesnic D, Sourbron SP (2016). Fitting the two-compartment
+model in DCE-MRI by linear inversion. Magn Reson Med. 76(3):998-1006.
+doi:10.1002/mrm.25991
 
 dcmri library: https://github.com/dcmri/dcmri
 """
@@ -117,8 +117,9 @@ def expconv(
 
     References
     ----------
-    .. [1] Flouri D, Lesnic D, Mayrovitz HN (2016). Comput Methods
-           Biomech Biomed Engin. 19(13):1359-1367.
+    .. [1] Flouri D, Lesnic D, Sourbron SP (2016). Fitting the
+           two-compartment model in DCE-MRI by linear inversion.
+           Magn Reson Med. 76(3):998-1006. doi:10.1002/mrm.25991
     """
     xp = get_array_module(f)
 

--- a/osipy/common/convolution/fft.py
+++ b/osipy/common/convolution/fft.py
@@ -10,8 +10,8 @@ simultaneously (e.g., convolving a single AIF with many IRFs).
 References
 ----------
     - scipy.signal.fftconvolve documentation
-    - Sourbron & Buckley (2013). Tracer kinetic modelling in MRI.
-      NMR in Biomedicine, 26(8), 1034-1048.
+    - Sourbron & Buckley (2013). Classic models for dynamic contrast-enhanced MRI.
+      NMR in Biomedicine, 26(8), 1004-1027.
 """
 
 from __future__ import annotations

--- a/osipy/common/fitting/least_squares.py
+++ b/osipy/common/fitting/least_squares.py
@@ -11,7 +11,8 @@ operations. Works identically on CPU (NumPy) and GPU (CuPy).
 References
 ----------
 Marquardt (1963). An Algorithm for Least-Squares Estimation of
-Nonlinear Parameters. SIAM Journal on Applied Mathematics.
+Nonlinear Parameters. Journal of the Society for Industrial and
+Applied Mathematics, 11(2), 431-441.
 """
 
 from __future__ import annotations

--- a/osipy/common/parameter_map.py
+++ b/osipy/common/parameter_map.py
@@ -11,7 +11,10 @@ notation for exponents (e.g. ``"mm^2/s"``, ``"min^-1"``).
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+   agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open
+   Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):1761-1773.
+   doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass, field

--- a/osipy/common/types.py
+++ b/osipy/common/types.py
@@ -8,8 +8,11 @@ References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
 .. [2] OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
-.. [3] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
-.. [4] Suzuki Y et al. MRM 2024;91(4):1411-1421.
+.. [3] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+   agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open
+   Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):1761-1773.
+   doi:10.1002/mrm.29840
+.. [4] Suzuki Y et al. MRM 2024;91(5):1743-1760. doi:10.1002/mrm.29815
 """
 
 from dataclasses import dataclass, field
@@ -144,7 +147,7 @@ class DCEAcquisitionParams(AcquisitionParams):
         Time between dynamic acquisitions in seconds.
     relaxivity : float
         Contrast agent relaxivity in mM⁻¹s⁻¹. Default is 4.5, matching
-        Gd-DTPA r1 in water at 3T (Noebauer-Huhmann et al.,
+        Gd-DTPA r1 in water at 3T (Sasaki et al.,
         Magn Reson Med Sci 2005;4(3):145, PMID 16462135: R1_3T_water=4.50).
         In vivo (plasma) r1 at 3T is lower (Pintaske et al.,
         Invest Radiol 2006;41:213, PMID 16481903 — direction only, no
@@ -165,7 +168,8 @@ class DCEAcquisitionParams(AcquisitionParams):
 
     References
     ----------
-    Tofts PS (1997). Modeling tracer kinetics in DCE-MRI. JMRI.
+    Tofts PS (1997). Modeling tracer kinetics in dynamic Gd-DTPA MR imaging.
+    JMRI 7(1):91-101. doi:10.1002/jmri.1880070113
     Dickie BR et al. MRM 2024;91(5):1761. doi:10.1002/mrm.29840 (CAPLEX).
     """
 
@@ -191,7 +195,10 @@ class DSCAcquisitionParams(AcquisitionParams):
 
     References
     ----------
-    Ostergaard L et al. (1996). High resolution CBF measurement. MRM.
+    Ostergaard L, Weisskoff RM, Chesler DA, Gyldensted C, Rosen BR. (1996).
+    High resolution measurement of cerebral blood flow using intravascular
+    tracer bolus passages. Part I: Mathematical approach and statistical
+    analysis. Magn Reson Med 36(5):715-725. doi:10.1002/mrm.1910360510
     """
 
     baseline_frames: int = 10
@@ -250,7 +257,10 @@ class IVIMAcquisitionParams(AcquisitionParams):
 
     References
     ----------
-    Le Bihan D et al. (1988). IVIM MR imaging. Radiology.
+    Le Bihan D, Breton E, Lallemand D, Aubin ML, Vignaud J, Laval-Jeantet M
+    (1988). Separation of diffusion and perfusion in intravoxel incoherent
+    motion MR imaging. Radiology 168(2):497-505.
+    doi:10.1148/radiology.168.2.3393671
     """
 
     b_values: "NDArray[np.floating[Any]]" = field(

--- a/osipy/dce/__init__.py
+++ b/osipy/dce/__init__.py
@@ -35,7 +35,7 @@ fit_model
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Tofts PS et al. J Magn Reson Imaging 1999;10(3):223-232.
 """
 

--- a/osipy/dce/models/__init__.py
+++ b/osipy/dce/models/__init__.py
@@ -13,7 +13,10 @@ Available models:
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Sourbron SP, Buckley DL. MRM 2011;66(3):735-745.
 """
 

--- a/osipy/dce/models/extended_tofts.py
+++ b/osipy/dce/models/extended_tofts.py
@@ -7,7 +7,10 @@ a vascular plasma compartment.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Tofts PS et al. J Magn Reson Imaging 1999;10(3):223-232.
 """
 
@@ -89,7 +92,10 @@ class ExtendedToftsModel(BasePerfusionModel[ExtendedToftsParams]):
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+           agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+           Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+           2024;91(5):1761-1773. doi:10.1002/mrm.29840
     .. [3] Tofts PS et al. J Magn Reson Imaging 1999;10(3):223-232.
     """
 

--- a/osipy/dce/models/patlak.py
+++ b/osipy/dce/models/patlak.py
@@ -9,7 +9,10 @@ NO scipy dependency - uses xp.linalg operations.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Patlak CS et al. J Cereb Blood Flow Metab 1983;3(1):1-7.
 """
 
@@ -106,7 +109,10 @@ class PatlakModel(BasePerfusionModel[PatlakParams]):
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+           contrast agent-based perfusion MRI: A consensus guidelines report
+           from the ISMRM Open Science Initiative for Perfusion Imaging
+           (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
     .. [3] Patlak CS et al. J Cereb Blood Flow Metab 1983;3(1):1-7.
     """
 

--- a/osipy/dce/models/tofts.py
+++ b/osipy/dce/models/tofts.py
@@ -5,7 +5,10 @@ This module implements the Standard Tofts model for DCE-MRI analysis.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report
+       from the ISMRM Open Science Initiative for Perfusion Imaging
+       (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Tofts PS, Kermode AG. MRM 1991;17(2):357-367.
 """
 
@@ -82,7 +85,10 @@ class ToftsModel(BasePerfusionModel[ToftsParams]):
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+           contrast agent-based perfusion MRI: A consensus guidelines report
+           from the ISMRM Open Science Initiative for Perfusion Imaging
+           (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
     .. [3] Tofts PS, Kermode AG. MRM 1991;17(2):357-367.
     """
 

--- a/osipy/dce/models/two_compartment.py
+++ b/osipy/dce/models/two_compartment.py
@@ -10,7 +10,10 @@ NO scipy dependency - uses xp.linalg operations.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report
+       from the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+       MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Sourbron SP, Buckley DL. MRM 2011;66(3):735-745.
 .. [4] Brix G et al. MRM 2004;52(2):420-429.
 """
@@ -94,7 +97,10 @@ class TwoCompartmentModel(BasePerfusionModel[TwoCompartmentParams]):
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+           contrast agent-based perfusion MRI: A consensus guidelines report
+           from the ISMRM Open Science Initiative for Perfusion Imaging
+           (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
     .. [3] Sourbron SP, Buckley DL. MRM 2011;66(3):735-745.
     """
 

--- a/osipy/dce/models/two_compartment_uptake.py
+++ b/osipy/dce/models/two_compartment_uptake.py
@@ -10,7 +10,10 @@ NO scipy dependency - uses xp.linalg operations.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report
+       from the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+       MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 .. [3] Sourbron SP, Buckley DL. MRM 2011;66(3):735-745.
 """
 
@@ -81,7 +84,10 @@ class TwoCompartmentUptakeModel(BasePerfusionModel[TwoCompartmentUptakeParams]):
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+           contrast agent-based perfusion MRI: A consensus guidelines report
+           from the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+           MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
     .. [3] Sourbron SP, Buckley DL. MRM 2011;66(3):735-745.
     """
 

--- a/osipy/dsc/__init__.py
+++ b/osipy/dsc/__init__.py
@@ -17,7 +17,10 @@ References
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
 .. [2] Ostergaard L et al. (1996). High resolution measurement of cerebral blood
    flow using intravascular tracer bolus passages. Magn Reson Med 36(5):715-725.
-.. [3] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [3] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+   agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open
+   Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):1761-1773.
+   doi:10.1002/mrm.29840
 """
 
 # Signal to concentration

--- a/osipy/dsc/concentration/__init__.py
+++ b/osipy/dsc/concentration/__init__.py
@@ -7,7 +7,10 @@ relaxation rate changes. Requires echo time TE (OSIPI: Q.MS1.005).
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM 2024;91(5):
+       1761-1773. doi:10.1002/mrm.29840
 """
 
 from osipy.dsc.concentration.signal_to_conc import (

--- a/osipy/dsc/concentration/signal_to_conc.py
+++ b/osipy/dsc/concentration/signal_to_conc.py
@@ -13,11 +13,14 @@ NO scipy dependency - uses custom Levenberg-Marquardt implementation.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Rosen BR et al. (1990). Contrast agents and cerebral hemodynamics.
-   Magn Reson Med 14(2):249-265.
+.. [2] Rosen BR et al. (1991). Contrast agents and cerebral hemodynamics.
+   Magn Reson Med 19(2):285-292.
 .. [3] Ostergaard L et al. (1996). High resolution measurement of cerebral blood
    flow using intravascular tracer bolus passages. Magn Reson Med 36(5):715-725.
-.. [4] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [4] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+   agent-based perfusion MRI: A consensus guidelines report from the ISMRM Open
+   Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+   2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass

--- a/osipy/dsc/deconvolution/__init__.py
+++ b/osipy/dsc/deconvolution/__init__.py
@@ -15,7 +15,10 @@ Two pathways are available:
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report
+       from the ISMRM Open Science Initiative for Perfusion Imaging
+       (OSIPI). MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from osipy.dsc.deconvolution.base import BaseDeconvolver

--- a/osipy/dsc/deconvolution/base.py
+++ b/osipy/dsc/deconvolution/base.py
@@ -11,7 +11,10 @@ tracer still present in the tissue at time t after an ideal bolus injection.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from
+   the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+   MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from abc import abstractmethod

--- a/osipy/dsc/deconvolution/svd.py
+++ b/osipy/dsc/deconvolution/svd.py
@@ -28,7 +28,10 @@ References
    estimating flow in MR perfusion-weighted imaging using singular value
    decomposition with a block-circulant deconvolution matrix.
    Magn Reson Med 50(1):164-174.
-.. [4] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [4] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from the
+   ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+   91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass

--- a/osipy/dsc/deconvolution/svd_fitters.py
+++ b/osipy/dsc/deconvolution/svd_fitters.py
@@ -342,7 +342,10 @@ class TikhonovFitter(BaseFitter):
 
     References
     ----------
-    .. [1] Calamante F et al. MRM 2003;50(4):813-825.
+    .. [1] Calamante F, Gadian DG, Connelly A. Quantification of
+       bolus-tracking MRI: improved characterization of the tissue
+       residue function using Tikhonov regularization. MRM
+       2003;50(6):1237-1247.
     """
 
     fitting_method_name = "tikhonov"

--- a/osipy/dsc/leakage/__init__.py
+++ b/osipy/dsc/leakage/__init__.py
@@ -8,7 +8,10 @@ blood-brain barrier breakdown. Estimates leakage coefficients K1
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from osipy.dsc.leakage.base import BaseLeakageCorrector

--- a/osipy/dsc/leakage/base.py
+++ b/osipy/dsc/leakage/base.py
@@ -7,7 +7,10 @@ compute perfusion parameters.
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from abc import abstractmethod

--- a/osipy/dsc/leakage/correction.py
+++ b/osipy/dsc/leakage/correction.py
@@ -19,7 +19,10 @@ References
 .. [3] Paulson ES, Schmainda KM (2008). Comparison of dynamic susceptibility-
    weighted contrast-enhanced MR methods: recommendations for measuring
    relative cerebral blood volume in brain tumors. Radiology 249(2):601-613.
-.. [4] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [4] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from the
+   ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+   91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass
@@ -132,7 +135,10 @@ def correct_leakage(
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report from
+       the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn
+       Reson Med 91(5):1761-1773. doi:10.1002/mrm.29840
 
     Examples
     --------
@@ -394,7 +400,7 @@ class BidirectionalCorrector(BaseLeakageCorrector):
     @property
     def reference(self) -> str:
         """Return primary literature citation."""
-        return "Bjornerud A et al. JCBFM 2011;31(1):215-228."
+        return "Bjornerud A et al. JCBFM 2011;31(10):2041-2053."
 
     def correct(self, delta_r2, aif, time, mask=None, **kwargs):
         """Perform bidirectional leakage correction."""

--- a/osipy/dsc/normalization.py
+++ b/osipy/dsc/normalization.py
@@ -11,7 +11,10 @@ References
 .. [2] Boxerman JL et al. (2006). Relative cerebral blood volume maps corrected
    for contrast agent extravasation significantly correlate with glioma tumor
    grade, whereas uncorrected maps do not. AJNR 27(4):859-867.
-.. [3] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [3] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from the
+   ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+   91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from __future__ import annotations
@@ -150,7 +153,9 @@ def normalize_to_white_matter(
     References
     ----------
     Wetzel SG et al. (2002). Relative cerebral blood volume measurements
-    in intracranial mass lesions. Radiology 224(2):334-341.
+    in intracranial mass lesions: interobserver and intraobserver
+    reproducibility study. Radiology 224(3):797-803.
+    doi:10.1148/radiol.2243011014.
 
     Examples
     --------

--- a/osipy/dsc/parameters/__init__.py
+++ b/osipy/dsc/parameters/__init__.py
@@ -8,7 +8,10 @@ Ta (OSIPI: Q.PH1.007).
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from osipy.dsc.parameters.maps import (

--- a/osipy/dsc/parameters/maps.py
+++ b/osipy/dsc/parameters/maps.py
@@ -17,9 +17,13 @@ References
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
 .. [2] Ostergaard L et al. (1996). High resolution measurement of cerebral blood
    flow using intravascular tracer bolus passages. Magn Reson Med 36(5):715-725.
-.. [3] Calamante F et al. (2010). Measuring cerebral blood flow using magnetic
+.. [3] Calamante F et al. (1999). Measuring cerebral blood flow using magnetic
    resonance imaging techniques. J Cereb Blood Flow Metab 19(7):701-735.
-.. [4] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+   doi:10.1097/00004647-199907000-00001
+.. [4] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from the
+   ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+   91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from dataclasses import dataclass
@@ -113,7 +117,10 @@ def compute_perfusion_maps(
     References
     ----------
     .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-    .. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+    .. [2] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+       contrast agent-based perfusion MRI: A consensus guidelines report from the
+       ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+       91(5):1761-1773. doi:10.1002/mrm.29840
 
     Examples
     --------

--- a/osipy/ivim/fitting/bayesian_ivim.py
+++ b/osipy/ivim/fitting/bayesian_ivim.py
@@ -1,14 +1,16 @@
 """Two-stage Bayesian IVIM fitting with empirical priors.
 
-Implements the Barbieri et al. (MRM 2020) approach:
+Implements the Barbieri et al. (MRM 2016) approach:
 1. Stage 1: Least-squares fit on all voxels
 2. Build empirical per-parameter priors from the population of Stage 1 fits
 3. Stage 2: MAP fitting with empirical priors and per-voxel initial guesses
 
 References
 ----------
-.. [1] Barbieri S et al. MRM 2020;83(6):2160-2172.
-       doi:10.1002/mrm.28060
+.. [1] Barbieri S, Donati OF, Froehlich JM, Thoeny HC. Impact of the
+       calculation algorithm on biexponential fitting of diffusion-weighted
+       MRI in upper abdominal organs. Magn Reson Med 2016;75(5):2175-2184.
+       doi:10.1002/mrm.25765
 """
 
 from __future__ import annotations

--- a/osipy/ivim/fitting/estimators.py
+++ b/osipy/ivim/fitting/estimators.py
@@ -18,7 +18,10 @@ References
 .. [2] Lemke A et al. (2011). Toward an optimal distribution of b values for
    intravoxel incoherent motion imaging. Magn Reson Imaging 29(6):766-776.
 .. [3] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [4] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [4] Dickie BR et al. (2024). A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from the
+   ISMRM Open Science Initiative for Perfusion Imaging (OSIPI). Magn Reson Med
+   91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 import logging

--- a/osipy/ivim/models/biexponential.py
+++ b/osipy/ivim/models/biexponential.py
@@ -21,12 +21,15 @@ References
 .. [2] Lemke A et al. (2010). An in vivo verification of the intravoxel
    incoherent motion effect in diffusion-weighted imaging of the abdomen.
    Magn Reson Med 64(6):1580-1585.
-.. [3] Federau C et al. (2014). IVIM perfusion imaging in acute stroke:
-   initial clinical experience. AJNR 35:256-262.
+.. [3] Federau C et al. (2014). Perfusion measurement in brain gliomas
+   with intravoxel incoherent motion MRI. AJNR 35:256-262.
    doi:10.3174/ajnr.A3686. PMID 23928134. Source for typical f, D, D*
    ranges in brain tissue.
 .. [4] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [5] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [5] Dickie BR et al. A community-endorsed open-source lexicon for
+   contrast agent-based perfusion MRI: A consensus guidelines report from
+   the ISMRM Open Science Initiative for Perfusion Imaging (OSIPI).
+   MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from abc import ABC, abstractmethod

--- a/osipy/pipeline/asl_pipeline.py
+++ b/osipy/pipeline/asl_pipeline.py
@@ -7,7 +7,7 @@ the OSIPI ASL Lexicon conventions.
 References
 ----------
 .. [1] OSIPI ASL Lexicon, https://osipi.github.io/ASL-Lexicon/
-.. [2] Suzuki Y et al. MRM 2024;91(4):1411-1421.
+.. [2] Suzuki Y et al. MRM 2024;91(5):1743-1760.
 """
 
 from collections.abc import Callable

--- a/osipy/pipeline/dce_pipeline.py
+++ b/osipy/pipeline/dce_pipeline.py
@@ -11,7 +11,10 @@ CAPLEX model registry (M.IC2.001 Parker, M.IC2.002 Georgiou).
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from __future__ import annotations

--- a/osipy/pipeline/dsc_pipeline.py
+++ b/osipy/pipeline/dsc_pipeline.py
@@ -10,7 +10,10 @@ The pipeline produces OSIPI CAPLEX-compliant perfusion maps
 References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
-.. [2] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [2] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI).
+       MRM 2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from __future__ import annotations

--- a/osipy/pipeline/ivim_pipeline.py
+++ b/osipy/pipeline/ivim_pipeline.py
@@ -9,7 +9,10 @@ References
 ----------
 .. [1] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
 .. [2] Le Bihan D et al. (1988). Radiology 168(2):497-505.
-.. [3] Dickie BR et al. MRM 2024. doi:10.1002/mrm.29840
+.. [3] Dickie BR et al. A community-endorsed open-source lexicon for contrast
+       agent-based perfusion MRI: A consensus guidelines report from the ISMRM
+       Open Science Initiative for Perfusion Imaging (OSIPI). MRM
+       2024;91(5):1761-1773. doi:10.1002/mrm.29840
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Correct 43 citations across 46 files that were fabricated (no such paper) or garbled (wrong title, author, year, journal, volume, or pages). Each corrected reference was verified against CrossRef/PubMed and confirmed to match the claim at its location.
