### PR TITLE
docs: remove blank lines that break REPL copy-paste in code examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ output/
 test_runs/
 .claude/
 site/
+.cache/
 
 # Local-only pipeline verification helper (machine-specific data paths)
 scripts/verify_local_pipelines.sh

--- a/docs/how-to/choose-population-aif.md
+++ b/docs/how-to/choose-population-aif.md
@@ -160,11 +160,9 @@ def adjust_aif_hematocrit(aif, hct=0.45):
     # Plasma fraction
     plasma_fraction = 1 - hct
     standard_plasma = 1 - 0.45
-
     # Scale concentration
     scale = standard_plasma / plasma_fraction
     adjusted_conc = aif.concentration * scale
-
     return osipy.ArterialInputFunction(
         time=aif.time,
         concentration=adjusted_conc,

--- a/docs/how-to/fit-multiple-models.md
+++ b/docs/how-to/fit-multiple-models.md
@@ -107,7 +107,6 @@ def compute_aic(r_squared, n_params, n_points):
     # Approximate residual sum of squares from R²
     # RSS = (1 - R²) * TSS, assume TSS = 1 for comparison
     rss = 1 - r_squared
-
     # AIC = n * log(RSS/n) + 2k
     # Simplified for comparison: -n * log(R²) + 2k
     aic = -n_points * np.log(np.maximum(r_squared, 1e-10)) + 2 * n_params
@@ -136,7 +135,6 @@ for name, result in results.items():
                      model_params[name], n_timepoints)
     bic = compute_bic(result.r_squared_map[combined_mask],
                      model_params[name], n_timepoints)
-
     print(f"  {name:12s}: AIC={aic.mean():.1f}, BIC={bic.mean():.1f}")
 ```
 
@@ -149,29 +147,22 @@ def select_best_model(results, mask, criterion='aic'):
     """Select best model per voxel based on information criterion."""
     model_names = list(results.keys())
     n_models = len(model_names)
-
     # Initialize criterion arrays
     shape = results[model_names[0]].r_squared_map.shape
     criteria = np.zeros((*shape, n_models))
-
     n_points = 60  # number of time points
-
     for i, name in enumerate(model_names):
         r2 = results[name].r_squared_map
         n_params = model_params[name]
-
         if criterion == 'aic':
             criteria[..., i] = compute_aic(r2, n_params, n_points)
         else:
             criteria[..., i] = compute_bic(r2, n_params, n_points)
-
     # Select model with lowest criterion
     best_model_idx = np.argmin(criteria, axis=-1)
-
     # Create selection map
     model_selection = np.zeros(shape, dtype=int)
     model_selection[mask] = best_model_idx[mask]
-
     return model_selection, model_names
 
 selection, names = select_best_model(results, combined_mask)
@@ -250,7 +241,6 @@ print("Tumor ROI Analysis:")
 for name, result in results.items():
     ktrans = result.parameter_maps['Ktrans'].values[tumor_mask & combined_mask]
     r2 = result.r_squared_map[tumor_mask & combined_mask]
-
     print(f"\n{name}:")
     print(f"  Ktrans: {ktrans.mean():.4f} ± {ktrans.std():.4f}")
     print(f"  R²:     {r2.mean():.4f}")

--- a/docs/how-to/handle-fitting-failures.md
+++ b/docs/how-to/handle-fitting-failures.md
@@ -235,21 +235,16 @@ def visualize_fitting_failures(result, concentration, time, aif, slice_idx=None)
     """Visualize fitting success and failures."""
     if slice_idx is None:
         slice_idx = result.quality_mask.shape[2] // 2
-
     quality = result.quality_mask[:, :, slice_idx]
     r_squared = result.r_squared_map[:, :, slice_idx]
-
     fig, axes = plt.subplots(2, 3, figsize=(12, 8))
-
     # Success/failure map
     axes[0, 0].imshow(quality, cmap='RdYlGn')
     axes[0, 0].set_title(f'Quality Mask\n(Green=valid)')
-
     # R² map
     im = axes[0, 1].imshow(r_squared, cmap='viridis', vmin=0, vmax=1)
     axes[0, 1].set_title('R² Map')
     plt.colorbar(im, ax=axes[0, 1])
-
     # R² histogram
     valid_r2 = result.r_squared_map[result.quality_mask > 0]
     axes[0, 2].hist(valid_r2, bins=50, color='steelblue')
@@ -257,7 +252,6 @@ def visualize_fitting_failures(result, concentration, time, aif, slice_idx=None)
     axes[0, 2].set_xlabel('R²')
     axes[0, 2].set_title('R² Distribution')
     axes[0, 2].legend()
-
     # Sample successful fit
     success_idx = np.where(quality > 0)
     if len(success_idx[0]) > 0:
@@ -265,7 +259,6 @@ def visualize_fitting_failures(result, concentration, time, aif, slice_idx=None)
         axes[1, 0].plot(time, concentration[x, y, slice_idx, :], 'ko', label='Data')
         axes[1, 0].set_title(f'Successful Fit\nR²={r_squared[x,y]:.3f}')
         axes[1, 0].legend()
-
     # Sample failed fit
     fail_idx = np.where(quality == 0)
     if len(fail_idx[0]) > 0:
@@ -273,20 +266,17 @@ def visualize_fitting_failures(result, concentration, time, aif, slice_idx=None)
         axes[1, 1].plot(time, concentration[x, y, slice_idx, :], 'ko', label='Data')
         axes[1, 1].set_title(f'Failed Fit\nR²={r_squared[x,y]:.3f}')
         axes[1, 1].legend()
-
     # Failure reasons
     axes[1, 2].axis('off')
     n_total = quality.size
     n_valid = (quality > 0).sum()
     n_low_r2 = (r_squared < 0.5).sum() - (quality == 0).sum()
-
     text = f"""Fitting Summary:
     Total voxels: {n_total}
     Valid fits: {n_valid} ({100*n_valid/n_total:.1f}%)
     Low R² (<0.5): {n_low_r2}
     """
     axes[1, 2].text(0.1, 0.5, text, fontsize=12, family='monospace')
-
     plt.tight_layout()
     return fig
 
@@ -305,22 +295,17 @@ Start with a complex model and fall back to a simpler one for failed voxels:
 def fit_with_fallback(concentration, aif, time, mask):
     # Try Extended Tofts first
     result = osipy.fit_model("extended_tofts", concentration, aif, time, mask=mask)
-
     # Find failed voxels
     failed = (result.quality_mask == 0) & mask
-
     if failed.sum() > 0:
         print(f"Retrying {failed.sum()} voxels with Standard Tofts")
-
         # Retry with simpler model
         result_simple = osipy.fit_model("tofts", concentration, aif, time,
                                         mask=failed)
-
         # Merge results
         # Note: Merging DCEFitResult objects requires manual attribute updates.
         # This is a simplified example—in practice, you would need to update
         # result.parameter_maps, result.quality_mask, and result.r_squared_map.
-
     return result
 
 result = fit_with_fallback(concentration, aif, time, mask)
@@ -335,7 +320,6 @@ Try multiple bound configurations and keep the best result:
 def fit_with_multiple_bounds(concentration, aif, time):
     best_result = None
     best_r2 = -np.inf
-
     # Try different bounds_override configurations
     bounds_configs = [
         # Default-like tight bounds
@@ -345,16 +329,13 @@ def fit_with_multiple_bounds(concentration, aif, time):
         # Narrow bounds for low-permeability tissue
         {'Ktrans': (0.0001, 0.1), 've': (0.1, 0.8), 'vp': (0.001, 0.05)},
     ]
-
     for bounds in bounds_configs:
         result = osipy.fit_model("extended_tofts", concentration, aif, time,
                                 bounds_override=bounds)
         mean_r2 = result.r_squared_map[result.quality_mask > 0].mean()
-
         if mean_r2 > best_r2:
             best_r2 = mean_r2
             best_result = result
-
     return best_result
 ```
 

--- a/docs/how-to/run-complete-pipeline.md
+++ b/docs/how-to/run-complete-pipeline.md
@@ -250,11 +250,9 @@ pipeline = DCEPipeline(config)
 results = {}
 for subject in subjects:
     print(f"Processing {subject}...")
-
     # Load subject data
     data = osipy.load_nifti(data_dir / subject / "perf" / f"{subject}_dce.nii.gz")
     time = np.arange(data.shape[-1]) * 3.5
-
     try:
         results[subject] = pipeline.run(data, time)
         valid = results[subject].quality_mask
@@ -311,12 +309,9 @@ class CustomDCEPipeline(osipy.DCEPipeline):
         """Custom masking logic."""
         # Call parent's method
         mask = super().create_mask()
-
         # Add custom filtering
         mask = mask & (self.t1_map > 500) & (self.t1_map < 3000)
-
         return mask
-
     def select_aif(self):
         """Use custom AIF."""
         # Load pre-computed AIF

--- a/docs/how-to/use-custom-aif.md
+++ b/docs/how-to/use-custom-aif.md
@@ -124,28 +124,23 @@ def check_aif_quality(aif):
     """Check AIF quality metrics."""
     time = aif.time
     conc = aif.concentration
-
     # Check for baseline before bolus
     baseline = conc[:5].mean()
     if baseline > 0.1:
         print("Warning: High baseline concentration")
-
     # Check peak is well-defined
     peak_idx = np.argmax(conc)
     peak_time = time[peak_idx]
     peak_conc = conc[peak_idx]
-
     if peak_idx < 3:
         print("Warning: Peak too early, may miss bolus arrival")
     if peak_idx > len(conc) - 5:
         print("Warning: Peak too late, may be truncated")
-
     # Check signal-to-noise
     tail_std = conc[-10:].std()
     snr = peak_conc / tail_std if tail_std > 0 else np.inf
     if snr < 10:
         print(f"Warning: Low SNR ({snr:.1f})")
-
     print(f"Peak: {peak_conc:.2f} mM at {peak_time:.1f} s")
     print(f"Estimated SNR: {snr:.1f}")
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -125,18 +125,15 @@ for i in range(shape[0]):
             ktrans = ktrans_true * (0.8 + 0.4 * np.random.rand())
             ve = ve_true * (0.8 + 0.4 * np.random.rand())
             vp = vp_true * (0.8 + 0.4 * np.random.rand())
-
             # Simple Extended Tofts forward model
             # (In practice, use osipy's model prediction)
             cp = aif.concentration
             kep = ktrans / ve
             time_min = time / 60  # Convert to minutes
-
             # Convolution integral (simplified)
             dt = time_min[1] - time_min[0]
             impulse = ktrans * np.exp(-kep * time_min)
             ct = np.convolve(cp, impulse)[:n_timepoints] * dt + vp * cp
-
             # Add noise
             noise = np.random.normal(0, 0.005, n_timepoints)
             concentration[i, j, k, :] = ct + noise


### PR DESCRIPTION
Fixes #160

Blank lines inside an indented block end that block in the Python REPL, so
pasting these examples into an interactive session failed with
`IndentationError`. Removed the offending blank lines from the affected
code examples.

| File | Lines removed |
|---|---|
| `docs/tutorials/getting-started.md` | 3 |
| `docs/how-to/handle-fitting-failures.md` | 19 |
| `docs/how-to/fit-multiple-models.md` | 10 |
| `docs/how-to/run-complete-pipeline.md` | 5 |
| `docs/how-to/use-custom-aif.md` | 5 |
| `docs/how-to/choose-population-aif.md` | 2 |