### PR TITLE
Changed flip angles in dce tutorial to list

### DIFF
--- a/docs/tutorials/dce-analysis.md
+++ b/docs/tutorials/dce-analysis.md
@@ -47,7 +47,7 @@ dce_dataset = osipy.load_nifti("dce_4d.nii.gz")
 vfa_data = osipy.load_nifti("vfa_images.nii.gz")
 
 # Define acquisition parameters
-flip_angles = np.array([2, 5, 10, 15])  # degrees
+flip_angles = [2, 5, 10, 15]  # degrees
 tr = 5.0  # Repetition time in ms
 
 # DCE timing


### PR DESCRIPTION
I found a small mistake in the DCE tutorial. The flip angles in there are defined as a numpy array (which is very reasonable). However, the [`_compute_t1_vfa_impl` function](https://github.com/OSIPI/osipy/blob/b289b3be5fa2a0e9c0b228a9531c83ad4e8de442/osipy/dce/t1_mapping/vfa.py#L152) has been written with only lists in mind. 

The call `osipy.compute_t1_map(vfa_data, method="vfa")`  in the DCE-MRI analysis tutorial fails when the flip angles are defined as numpy arrays (see stacktrace below). Since the type hint states it should be a list anyways I thought it would be reasonable enough to only fix the documentation.

## Stacktrace
```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[13], line 8
      4     tr=tr, flip_angles=flip_angles
      5 )
      6 
      7 # Compute T1 map using Variable Flip Angle method
----> 8 t1_result = osipy.compute_t1_map(vfa_data, method="vfa")
      9 
     10 # The result is a T1MappingResult with t1_map (ParameterMap) and quality_mask
     11 t1_values = t1_result.t1_map.values

File [~/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/__init__.py:59](http://localhost:8888/home/dsmits/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/__init__.py#line=58), in compute_t1_map(dataset, method)
     29 """Compute T1 map from multi-flip-angle or Look-Locker data.
     30 
     31 Parameters
   (...)     56 >>> print(f"Mean T1: {result.t1_map.statistics()['mean']:.0f} ms")
     57 """
     58 t1_func = get_t1_method(method)
---> 59 return t1_func(dataset)

File [~/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/vfa.py:380](http://localhost:8888/home/dsmits/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/vfa.py#line=379), in compute_t1_vfa(dataset, method, signal, flip_angles, tr, mask)
    370     # Create temporary dataset
    371     dataset = PerfusionDataset(
    372         data=signal,
    373         affine=np.eye(4),
   (...)    377         quality_mask=mask,
    378     )
--> 380 return _compute_t1_vfa_impl(dataset, method)

File [~/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/vfa.py:152](http://localhost:8888/home/dsmits/projects/OSIPY/osipy-test/.venv/lib/python3.14/site-packages/osipy/dce/t1_mapping/vfa.py#line=151), in _compute_t1_vfa_impl(dataset, method)
    149     raise DataValidationError(msg)
    151 params = dataset.acquisition_params
--> 152 if not params.flip_angles:
    153     msg = "VFA T1 mapping requires flip_angles in acquisition_params"
    154     raise DataValidationError(msg)

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```